### PR TITLE
#7468 - Corrige a seleção de estados no checkout em dispositivos android

### DIFF
--- a/templates/checkout/complete.liquid
+++ b/templates/checkout/complete.liquid
@@ -147,7 +147,7 @@
                           </div>
                         </div>
                         <div class="col-md-6">
-                          <div class="form-group {{ required }} {% if form.errors.address_zip_code %}has-error{% endif %}">
+                          <div class="form-group {{ required }} {% if form.errors.address_zip_code %}has-error{% endif %}" data-tap-disabled="true">
                             <label class="control-label">{{ 'checkout.complete.address_zip_code' | t }}</label>
                             <input type="text" id="user-cep" name="user[address_attributes][zip_code]"
                                    value="{{ address.zip_code }}" class="form-control" {{ required }}>


### PR DESCRIPTION
Está ocorrendo um bug (https://productforums.google.com/forum/#!topic/chrome/Q4Rt6d0C4Qo) com o site de algumas escolas quando o usuário tenta selecionar o estado na etapa em que ele precisa completar seu cadastro. O select de estados não exibe os estados ao ser pressionado. Esse problema ocorre em alguns dispositivos **Android** por conta de um bug em uma atualização do chrome referente a `passive event listeners`. Esses listeners ficam ouvindo algumas ações para tentar melhorar a experiência do usuário, porém este problema está ocorrendo em algumas ocasiões.

Para resolver o problema foi necessário acrescentar `data-tap-disabled="true"` a div que contém o select para evitar que o evento de toque seja interceptado.