### PR TITLE
Corrige seleção de estados na etapa de completar o cadastro

### DIFF
--- a/templates/checkout/complete.liquid
+++ b/templates/checkout/complete.liquid
@@ -141,7 +141,7 @@
                           </div>
                         </div>
                         <div class="col-md-6">
-                          <div class="form-group {{ required }} {% if form.errors.address_state %}has-error{% endif %}">
+                          <div class="form-group {{ required }} {% if form.errors.address_state %}has-error{% endif %}" data-tap-disabled="true">
                             <label class="control-label">{{ 'checkout.complete.address_state' | t }}</label>
                             {% include "select-address", selected_state: address.state %}
                           </div>


### PR DESCRIPTION
Está ocorrendo um bug (https://productforums.google.com/forum/#!topic/chrome/Q4Rt6d0C4Qo) com o site de algumas escolas quando o usuário tenta selecionar o estado na etapa em que ele precisa completar seu cadastro. O select de estados não exibe os estados ao ser pressionado. Esse problema ocorre em alguns dispositivos Android por conta de um bug em uma atualização do chrome referente a passive event listeners. Esses listeners ficam ouvindo algumas ações para tentar melhorar a experiência do usuário, porém este problema está ocorrendo em algumas ocasiões.

Para resolver o problema foi necessário acrescentar data-tap-disabled="true" a div que contém o select para evitar que o evento de toque seja interceptado.