### PR TITLE
#7527 - Corrige a label com a resposta correta para questão tipo `verdadeiro ou falso`

### DIFF
--- a/snippets/activities/quiz/answers.liquid
+++ b/snippets/activities/quiz/answers.liquid
@@ -148,7 +148,7 @@
             {% if answer.approved? %}
               <div class="alert alert-info">
                   <span class="question-right-answer">
-                    <strong>{{ 'quiz.right_answer' | t }}:</strong> {{ correct_option }}
+                    <strong>{{ 'quiz.right_answer' | t }}:</strong> {% if correct_option.correct %} {{ 'quiz.true' | t }} {% else %} {{ 'quiz.false' | t }} {% endif %}
                   </span>
               </div>
             {% endif %}


### PR DESCRIPTION
O label com a resposta correta na tela de questões já respondidas estava exibindo todo o JSON da opção correta. Isso ocorria porque o tema estava exibindo todo o objeto completo ao invés de a resposta correta.

Para corrigir foi necessário alterar o arquivo `snippets/activities/quiz/answers.liquid` mudando:

```{{ correct_option }}```

para

```{% if correct_option.correct %} {{ 'quiz.true' | t }} {% else %} {{ 'quiz.false' | t }} {% endif %}```

na linha 151.
