### PR TITLE
#7527 - Mostra ícone na sidebar para indicar que questão foi finalizada após request

### DIFF
--- a/assets/js/components/examQuestionForm.js
+++ b/assets/js/components/examQuestionForm.js
@@ -23,6 +23,14 @@
     // bind all form's textareas for all types of typing
     $(document).on('input propertychange', '#exam_answer_form', app.checkFormValidity);
 
+    $(document).ajaxSuccess(function(event, jqXHR, ajaxInfo, data) {
+      if (ajaxInfo.url == "/exam_answers" && jqXHR.status == 200) {
+        const lessonID = $('#js-media-player').data('lesson-id');
+        $('.icon-check.js-completed-icon', `#lesson-${lessonID}`).removeClass('hide');
+        $('.icon-clock.js-in-progress-icon', `#lesson-${lessonID}`).addClass('hide');
+      }
+    });
+
     $(document).trigger('app:bind:bind_exam_question_form');
   };
 })();


### PR DESCRIPTION
O ícone que indica que a questão foi finalizada ![captura de tela 2017-01-04 as 13 27 33](https://cloud.githubusercontent.com/assets/646798/21649788/a24fc142-d281-11e6-8eda-6f07be3cddbc.png) não estava sendo exibido após o envio do formulário.

O código abaixo foi acrescentado no arquivo `assets/js/components/examQuestionForm.js` para acrescentar o ícone caso a requisição retorne com sucesso:

```
    $(document).ajaxSuccess(function(event, jqXHR, ajaxInfo, data) {
        if (ajaxInfo.url == "/exam_answers" && jqXHR.status == 200) {
            const lessonID = $('#js-media-player').data('lesson-id');
            $('.icon-check.js-completed-icon', `#lesson-${lessonID}`).removeClass('hide');
            $('.icon-clock.js-in-progress-icon', `#lesson-${lessonID}`).addClass('hide');
        }
    });
```