### PR TITLE
Remove etapa de checkout quando a compra for gratuita

### DIFF
--- a/snippets/checkout/security-box.liquid
+++ b/snippets/checkout/security-box.liquid
@@ -1,3 +1,4 @@
+{% if order.kind != 'free' %}
 <div class="security-widget">
   <div class="row">
     <div class="col-md-2 text-center ssl-lock">
@@ -16,3 +17,4 @@
     </div>
   </div>
 </div>
+{% endif %}

--- a/templates/cart.liquid
+++ b/templates/cart.liquid
@@ -75,9 +75,7 @@
             <div class="panel panel-default">
               <div class="panel-body">
 
-                {% if order.kind != 'free' %}
-                  {% include "checkout/security-box" %}
-                {% endif %}
+                {% include "checkout/security-box" %}
 
                 {% include "checkout/totals-box" %}
 

--- a/templates/cart.liquid
+++ b/templates/cart.liquid
@@ -74,7 +74,11 @@
           <div class="col-md-5 cart-sidebar">
             <div class="panel panel-default">
               <div class="panel-body">
-                {% include "checkout/security-box" %}
+
+                {% if order.kind != 'free' %}
+                  {% include "checkout/security-box" %}
+                {% endif %}
+
                 {% include "checkout/totals-box" %}
 
                 {% if order.items.size > 0 %}
@@ -92,7 +96,7 @@
 
                 {% include "checkout/payment-methods-box" %}
 
-                {% if order.items.size > 0 and order.kind != 'subscription' and order.amount_to_pay == order.total %}
+                {% if order.items.size > 0 and order.kind != 'subscription' and order.amount_to_pay == order.total and order.kind != 'free' %}
                   <div class="coupon-widget panel panel-default">
                     <div class="panel-heading">
                       <h4 class="panel-title">{{ 'checkout.coupon' | t }}</h4>

--- a/templates/checkout/connect.liquid
+++ b/templates/checkout/connect.liquid
@@ -6,7 +6,11 @@
       {% include "checkout/title-box" %}
       <div class="col-md-7 cart-wizard">
         <div class="wizard">
-          {% include "checkout/wizard-header", step: 1 %}
+
+          {% if order.kind != 'free' %}
+            {% include "checkout/wizard-header", step: 1 %}
+          {% endif %}
+
           <div class="wizard-content">
             <!-- <div class="note note-warning">
               <h4 class="note-title">{{ 'general.attention' | t }}</h4>


### PR DESCRIPTION
Esconde a caixa com informações do moip e o formulário para inserir cupom de desconto quando a compra for gratuita:

**snippets/checkout/security-box.liquid**

```
{% if order.kind != 'free' %}
.
.
.
{% endif %}
```

**templates/cart.liquid**

```
{% if order.items.size > 0 and order.kind != 'subscription' and order.amount_to_pay == order.total and order.kind != 'free' %}

```

Esconde os passos do wizard de checkout na tela de login ou cadastro quando a compra for gratuita.

**templates/checkout/connect.liquid**

```
{% if order.kind != 'free' %}
    {% include "checkout/wizard-header", step: 1 %}
{% endif %}
```

**Compras não gratuitas ficarão assim:**

![captura de tela 2017-01-06 as 12 11 06](https://cloud.githubusercontent.com/assets/646798/21722129/1a0db872-d40a-11e6-96c0-d5bb0c95676b.png)

![captura de tela 2017-01-06 as 12 11 16](https://cloud.githubusercontent.com/assets/646798/21722134/2169480c-d40a-11e6-8373-e6fdbe486973.png)

**Compras gratuitas ficarão assim:**

![captura de tela 2017-01-06 as 12 11 35](https://cloud.githubusercontent.com/assets/646798/21722156/3324b98c-d40a-11e6-99fc-ef150d9058d6.png)

![captura de tela 2017-01-06 as 12 11 42](https://cloud.githubusercontent.com/assets/646798/21722159/38dfbb06-d40a-11e6-8dcc-b3379c4198ed.png)
