### PR TITLE
Remove label dos campos customizados do tipo texto na tela de cadastro

### DIFF
--- a/templates/student/register.liquid
+++ b/templates/student/register.liquid
@@ -78,7 +78,6 @@
             </div>
           {% else %}
             <div class="form-group">
-              <label class="control-label">{{ field.title }}</label>
               <input type="{{field.type}}" value="{{field.value}}" name="customs[{{field.slug}}]" class="form-control" placeholder="{{field.placeholder}}" {% if field.required %} required {% endif %} />
             </div>
         {% endcase %}


### PR DESCRIPTION
Os campos customizados do tipo texto estavam exibindo a label na tela de cadastro de usuário, porém nessa tela somente os placeholder são exibidos por padrão:

![captura de tela 2017-02-08 as 18 04 19](https://cloud.githubusercontent.com/assets/646798/22757393/4ffd6804-ee29-11e6-919a-8b588299f6e8.png)

Para resolver o problema a linha abaixo foi removido do arquivo **templates/student/register.liquid:81**:

```<label class="control-label">{{ field.title }}</label>```