### PR TITLE
Remove dados do cartão no checkout do SparkPay

### DIFF
--- a/templates/checkout/payment.liquid
+++ b/templates/checkout/payment.liquid
@@ -302,6 +302,10 @@
     spark_pay_token = $('input[name="order[spark_pay_temp_token]"]');
 
     spark_pay_token.on('change', function() {
+      $('input[name="order[credit_card][number]"]').val('');
+      $('input[name="order[credit_card][expiry]"]').val('');
+      $('input[name="order[credit_card][cvc]"]').val('');
+
       $('#card-form').submit();
     });
 


### PR DESCRIPTION
### WHAT
Quando utilizado o SparkPay, o fluxo de pagamento utiliza o hash do cartão de crédito retornado pela ingenico, não sendo necessário enviar os dados do cartão para o backend.

### HOW
Removendo os campos do formulário após o retorno do hash pela ingenico e antes do submit para o backend