### PR TITLE
min legth fix to 7

### DIFF
--- a/templates/checkout/payment.liquid
+++ b/templates/checkout/payment.liquid
@@ -138,7 +138,7 @@
                                  name="order[credit_card][expiry]"
                                  value="{{ credit_card.expiry }}"
                                  class="form-control"
-                                 minlength=6
+                                 minlength=7
                                  placeholder="{{'checkout.placeholder.creditcard_expiry' | t }}" 
                                  {% if credit_card.active %}
                                    disabled


### PR DESCRIPTION
Após teste, foi verificado que o **/** que separa o ano do mês é contabilizado como caractere, então foi mudado de 6 para 7 considerando o mesmo.