### PR TITLE
Add disabled attr on payment button aft 1st click

### DIFF
--- a/templates/express_checkout/payment.liquid
+++ b/templates/express_checkout/payment.liquid
@@ -419,6 +419,7 @@
       });
 
       $(currentFormIdentifier).submit();
+      $("#btn-finalize-purchase").attr("disabled", true);
 
     });
   });


### PR DESCRIPTION
# Fix problem with multiples payments in the same order

Link to task on software project manager

## Changes outline

I changed the payment.liquid in express_checkout

## Expected behaviour

When user click in payment the first time, we add disabled attribute in the same button in order to block multiple payments in the same order
