### PR TITLE
Removendo protecao duplicada answer nula

### DIFF
--- a/snippets/activities/file_upload/answers.liquid
+++ b/snippets/activities/file_upload/answers.liquid
@@ -1,5 +1,5 @@
 <div id="sent-files">
-  {% if answer.try(:files).try(:size) && answer.try(:files).try(:size) > 0 %}
+  {% if answer.files.size > 0 %}
     <h4>{{ 'upload.files_sent' | t }}</h4>
 
     {% for file in answer.files %}
@@ -16,7 +16,7 @@
   {% endif %}
 </div>
 
-{% if answer.try(:corrected_at) %}
+{% if answer.corrected_at %}
   <div class="alert alert-info">
     <span class="question-comment">
       <strong>{{ 'upload.teacher_comment' | t }}:</strong> {{ answer.comment }}

--- a/snippets/activities/quiz/answers.liquid
+++ b/snippets/activities/quiz/answers.liquid
@@ -1,4 +1,4 @@
-{% if answer.try(:corrected_at) %}
+{% if answer.corrected_at %}
   {% if lesson.min_grade > 0 %}
 
     {% assign questions_size = answer.exam_question_answers.size %}


### PR DESCRIPTION
Está havendo uma duplicidade na proteção para answers inexistentes.
[Essa verificação](https://github.com/Edools/elegance/blob/master/templates/activities/quiz.liquid#L1) e [essa aqui](https://github.com/Edools/elegance/blob/master/snippets/activities/file_upload.liquid#L5) impedem que answer seja vazio.