### PR TITLE
[Master] - Adicionando accept_invitation_url nos emails de confirmação de pagamento

### DIFF
--- a/mailers/boleto_payment_confirmed_express_checkout.liquid
+++ b/mailers/boleto_payment_confirmed_express_checkout.liquid
@@ -182,7 +182,11 @@
                                                          <p style="text-align: center;"><span style="font-size: 14px;">Boas-not&iacute;cias! O seu boleto foi compensado e voc&ecirc; j&aacute; pode aproveitar seu conte&uacute;do.</span></p>
 
                                                          {% if user.confirmed_at == nil %}
-                                                            <p style="text-align: center;font-weight:bold;"><span style="font-size: 14px;">Estamos enviando agora um email para você definir sua senha. Procure-o em sua caixa de entrada e comece já!</p>
+                                                            <p style="text-align: center;font-weight:bold;"><span style="font-size: 14px;">
+                                                              <a href="{{ accept_invitation_url }}" style="display:inline-block;background:#2cc3cc;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:100%;Margin:0;text-decoration:none;text-transform:none;padding:11px 32px 11px 32px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                                                Definir senha e criar conta
+                                                              </a>
+                                                            </p>
                                                          {% endif %}
                                                       </div>
                                                    </td>

--- a/mailers/boleto_payment_confirmed_express_checkout.liquid
+++ b/mailers/boleto_payment_confirmed_express_checkout.liquid
@@ -183,7 +183,7 @@
 
                                                          {% if user.confirmed_at == nil %}
                                                             <p style="text-align: center;font-weight:bold;"><span style="font-size: 14px;">
-                                                              <a href="{{ accept_invitation_url }}" style="display:inline-block;background:#2cc3cc;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:100%;Margin:0;text-decoration:none;text-transform:none;padding:11px 32px 11px 32px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                                              <a href="{{ accept_invitation_url }}" style="display:inline-block;background:#2cc3cc;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:100%;margin: 25px 0px 0px 0px;text-decoration:none;text-transform:none;padding:11px 32px 11px 32px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
                                                                 Definir senha e criar conta
                                                               </a>
                                                             </p>

--- a/mailers/boleto_payment_confirmed_express_checkout.liquid
+++ b/mailers/boleto_payment_confirmed_express_checkout.liquid
@@ -182,7 +182,7 @@
                                                          <p style="text-align: center;"><span style="font-size: 14px;">Boas-not&iacute;cias! O seu boleto foi compensado e voc&ecirc; j&aacute; pode aproveitar seu conte&uacute;do.</span></p>
 
                                                          {% if user.confirmed_at == nil %}
-                                                            <p style="text-align: center;font-weight:bold;"><span style="font-size: 14px;">
+                                                            <p style="text-align: center;font-weight:bold;">
                                                               <a href="{{ accept_invitation_url }}" style="display:inline-block;background:#2cc3cc;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:100%;margin: 25px 0px 0px 0px;text-decoration:none;text-transform:none;padding:11px 32px 11px 32px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
                                                                 Definir senha e criar conta
                                                               </a>

--- a/mailers/credit_card_payment_confirmed_express_checkout.liquid
+++ b/mailers/credit_card_payment_confirmed_express_checkout.liquid
@@ -182,7 +182,7 @@
                                                          <p style="text-align: center;"><span style="font-size: 14px;">Boas-not&iacute;cias, {{ user.first_name }}. Voc&ecirc; j&aacute; pode acessar e aproveitar o conte&uacute;do do seu produto. Comece agora:</span></p>
 
                                                          {% if user.confirmed_at == nil %}
-                                                            <p style="text-align: center;font-weight:bold;"><span style="font-size: 14px;">
+                                                            <p style="text-align: center;font-weight:bold;">
                                                               <a href="{{ accept_invitation_url }}" style="display:inline-block;background:#2cc3cc;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:100%;margin: 25px 0px 0px 0px;text-decoration:none;text-transform:none;padding:11px 32px 11px 32px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
                                                                 Definir senha e criar conta
                                                               </a>

--- a/mailers/credit_card_payment_confirmed_express_checkout.liquid
+++ b/mailers/credit_card_payment_confirmed_express_checkout.liquid
@@ -183,7 +183,7 @@
 
                                                          {% if user.confirmed_at == nil %}
                                                             <p style="text-align: center;font-weight:bold;"><span style="font-size: 14px;">
-                                                              <a href="{{ accept_invitation_url }}" style="display:inline-block;background:#2cc3cc;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:100%;Margin:0;text-decoration:none;text-transform:none;padding:11px 32px 11px 32px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                                              <a href="{{ accept_invitation_url }}" style="display:inline-block;background:#2cc3cc;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:100%;margin: 25px 0px 0px 0px;text-decoration:none;text-transform:none;padding:11px 32px 11px 32px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
                                                                 Definir senha e criar conta
                                                               </a>
                                                             </p>

--- a/mailers/credit_card_payment_confirmed_express_checkout.liquid
+++ b/mailers/credit_card_payment_confirmed_express_checkout.liquid
@@ -182,7 +182,11 @@
                                                          <p style="text-align: center;"><span style="font-size: 14px;">Boas-not&iacute;cias, {{ user.first_name }}. Voc&ecirc; j&aacute; pode acessar e aproveitar o conte&uacute;do do seu produto. Comece agora:</span></p>
 
                                                          {% if user.confirmed_at == nil %}
-                                                            <p style="text-align: center;font-weight:bold;"><span style="font-size: 14px;">Estamos enviando agora um email para você definir sua senha. Procure-o em sua caixa de entrada e comece já!</p>
+                                                            <p style="text-align: center;font-weight:bold;"><span style="font-size: 14px;">
+                                                              <a href="{{ accept_invitation_url }}" style="display:inline-block;background:#2cc3cc;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:100%;Margin:0;text-decoration:none;text-transform:none;padding:11px 32px 11px 32px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                                                Definir senha e criar conta
+                                                              </a>
+                                                            </p>
                                                          {% endif %}
                                                       </div>
                                                    </td>


### PR DESCRIPTION
### Fecha o(s) issue(s) :heavy_check_mark:

* [SMD-106](https://technical-solutions-herospark.atlassian.net/browse/SMD-106)

### Qual o tipo desse PR? :label:

* Improvement

### Por que essa alteração é necessária? :cop:

Alguns alunos não "recebem" o email que cria a senha do usuário após a compra do curso, uma solução que iremos testar é  incluir o link de criação de senha junto ao email de confirmação de compra. 

### Como isso resolve o problema? :scroll:

* Eu adicionei ```:accept_invitation_url``` nas variaveis liquid para os emails de confirmação de compra.
  * `credit_card_payment_confirmed_express_checkout`
  * `boleto_payment_confirmed_express_checkout`  

### Comportamento esperado :dart:

* Quando uma compra é confirmada, o link de criação de senha deve ser entregue junto com o email de confirmação

![image](https://user-images.githubusercontent.com/403876/102234493-19afbf80-3ed0-11eb-89c5-cdb392e66bab.png)

### Riscos e obervações :warning:

* não tem

### PR's relacionados

core
* [dev] https://github.com/Edools/core/pull/5441
* [dev old] https://github.com/Edools/core/pull/5405
* [dev old] https://github.com/Edools/core/pull/5387
* [dev old] https://github.com/Edools/core/pull/5402

elegance
* [master] https://github.com/Edools/elegance/pull/449
* [dev] https://github.com/Edools/elegance/pull/450

members_theme
* [master] https://github.com/Edools/members_theme/pull/99
* [dev] https://github.com/Edools/members_theme/pull/98

