### PR TITLE
Habilitar uso de cupom de 100% de desconto

### DIFF
--- a/snippets/express_checkout/totals-box.liquid
+++ b/snippets/express_checkout/totals-box.liquid
@@ -124,6 +124,29 @@
 </style>
 
 <script>
+
+   {% if paymentOption.total == 0 %}
+    $(document).ready(() => {
+      $("#tab-payment-methods").html("\
+        <li role='presentation'>\
+          <a href='#credit-card' id='credit-card-tab' role='tab' data-toggle='tab'\
+             aria-controls='credit-card'\
+             aria-expanded='false'\
+             data-toggle='pill'>\
+            <i class='fal fa-credit-card'></i> Crédito \
+          </a>\
+        </li>\
+        <li class='active' role='presentation'>\
+          <a href='#boleto' id='boleto-tab' role='tab' data-toggle='tab' aria-controls='boleto'\
+             aria-expanded='true'\
+             data-toggle='pill'>\
+            <i class='fal fa-barcode-alt'></i> Boleto\
+          </a>\
+        </li>\
+      ");
+    });
+  {% endif %} 
+
   var coupon = '{{ coupon }}';
 
   $('#js-input-coupon-container').hide();

--- a/snippets/express_checkout/totals-box.liquid
+++ b/snippets/express_checkout/totals-box.liquid
@@ -146,6 +146,28 @@
       ");
     });
   {% endif %} 
+  
+  $('#link-remove-coupon').click(function(){
+    $("#tab-payment-methods").html("\
+        <li class='active' role='presentation'>\
+          <a href='#credit-card' id='credit-card-tab' role='tab' data-toggle='tab'\
+             aria-controls='credit-card'\
+             aria-expanded='true'\
+             data-toggle='pill'>\
+            <i class='fal fa-credit-card'></i> Crédito \
+          </a>\
+        </li>\
+        <li role='presentation'>\
+          <a href='#boleto' id='boleto-tab' role='tab' data-toggle='tab'\
+             aria-controls='boleto'\
+             aria-expanded='false'\
+             data-toggle='pill'>\
+            <i class='fal fa-barcode-alt'></i> Boleto\
+          </a>\
+        </li>\
+      ");
+    $(".wizard").css("display","block");
+  })
 
   var coupon = '{{ coupon }}';
 


### PR DESCRIPTION
# [Sparkpay] não está sendo possível aplicar cupons de 100%.

https://technical-solutions-herospark.atlassian.net/browse/ED-151

## O que foi feito

* Para dar um _bypass_ da Adyen e permitir a compra de um produto que custa 0 reais foi realizado um tratamento para o fluxo de uma compra automaticamente aprovada após o submit. 
* Foi adicionado um script que identifica o usuário de cupom integral e canaliza o fluxo do mesmo para a solução acima.
* 
## Resultado esperado

* Quando o cliente insere um cupom integral, basta ele preencher os campos de identificação, clicar em finalizar e a compra estará concluída.

## Modificações de front-end

Foi feito um Javascript que insere a interface necessária para encaminhar o cliente de cupom integral ao fluxo desejado.
