### PR TITLE
Change default_payment_option variable to current_payment_option

### DIFF
--- a/snippets/product/buy.liquid
+++ b/snippets/product/buy.liquid
@@ -1,38 +1,39 @@
 <div class="enroll">
   {% assign has_express_checkout = current_school | has_feature: 'express_checkout' %}
-  {% assign first_option = product.payment_options[0] %}
-  {% assign oldest_payment_option = product.payment_options | sort: "created_at" | first %}
-  {% if first_option %}
+
+  {% assign current_payment_option = product.current_payment_option %}
+
+  {% if current_payment_option %}
     {% capture product_price %}
-      {{ first_option.price | money_option_presentation_with_taxes: first_option.kind,
-        first_option.period, gateway, first_option }}
+      {{ current_payment_option.price | money_option_presentation_with_taxes: current_payment_option.kind,
+        current_payment_option.period, gateway, current_payment_option }}
     {% endcapture %}
 
     {% capture product_base_price %}
-      {{ first_option.base_price | money_option_presentation_with_taxes: first_option.kind,
-        first_option.period, gateway, first_option }}
+      {{ current_payment_option.base_price | money_option_presentation_with_taxes: current_payment_option.kind,
+        current_payment_option.period, gateway, current_payment_option }}
     {% endcapture %}
 
     <div class="price">
-      {% if first_option.promotional == true %}
+      {% if current_payment_option.promotional == true %}
         <p class="base-price">
           <strike>{{ product_base_price }}</strike>
         </p>
       {% endif %}
 
       {% if has_express_checkout == true %}
-        {{ oldest_payment_option.price | money_option_presentation: oldest_payment_option.kind, oldest_payment_option.period, 'full', 1 }}
+        {{ current_payment_option.price | money_option_presentation: current_payment_option.kind, current_payment_option.period, 'full', 1 }}
       {% else %}
-        {% if first_option.kind == 'subscription' %}
-          {{ first_option.price | money_option_presentation: first_option.kind, first_option.period, 'full', 1 }}
+        {% if current_payment_option.kind == 'subscription' %}
+          {{ current_payment_option.price | money_option_presentation: current_payment_option.kind, current_payment_option.period, 'full', 1 }}
         {% else %}
           {{ product_price }}
         {% endif %}
       {% endif %}
 
 
-      {% if first_option.trials > 0 %}
-        <div>{{ 'product.trial' | t: count: first_option.trials }}</div>
+      {% if current_payment_option.trials > 0 %}
+        <div>{{ 'product.trial' | t: count: current_payment_option.trials }}</div>
       {% endif %}
     </div>
 
@@ -65,7 +66,7 @@
 
     <div class="btn-group">
       {% if has_express_checkout == true %}
-        {{ 'product.buy' | t | add_to_cart_link: product, oldest_payment_option, 'btn btn-primary btn-lg' }}
+        {{ 'product.buy' | t | add_to_cart_link: product, current_payment_option, 'btn btn-primary btn-lg' }}
       {% else %}
         {% if product.payment_options.size > 1 %}
           <button type="button" class="btn btn-primary btn-lg dropdown-toggle" data-toggle="dropdown"
@@ -94,12 +95,12 @@
             {% endfor %}
           </ul>
         {% else %}
-          {% if gateway.gateway == 'hotmart' and first_option.kind != 'free' %}
-            <a class="hotmart-fb btn btn-primary btn-lg" href="{{ first_option.hotmart_config.hotmart_checkout_url }}">
+          {% if gateway.gateway == 'hotmart' and current_payment_option.kind != 'free' %}
+            <a class="hotmart-fb btn btn-primary btn-lg" href="{{ current_payment_option.hotmart_config.hotmart_checkout_url }}">
               {{ 'product.buy' | t }}
             </a>
           {% else %}
-            {{ 'product.buy' | t | add_to_cart_link: product, first_option, 'btn btn-primary btn-lg' }}
+            {{ 'product.buy' | t | add_to_cart_link: product, current_payment_option, 'btn btn-primary btn-lg' }}
           {% endif %}
         {% endif %}
       {% endif %}


### PR DESCRIPTION
# Change default_payment_option variable to current_payment_option

[Link to task](https://technical-solutions-herospark.atlassian.net/browse/SMEM-93?atlOrigin=eyJpIjoiMGEzNzIwNGU2YzA1NDc5M2I0MzY0OWNjMTNiZDM4NTgiLCJwIjoiaiJ9)

## Changes outline

* We now have a current_payment_option variable within the product object.
* The current_payment_option variable has the payment method chosen by the producer (default, last registered)

## Expected behaviour

* Now when an offer is set as a default, we will have no problem continuing to get the last registered offer.