### PR TITLE
Correction of installments price view option in the cards of the home

### DIFF
--- a/snippets/product/product-card.liquid
+++ b/snippets/product/product-card.liquid
@@ -37,7 +37,7 @@
         {% if has_express_checkout == true %}
           {% if gateway.price_format == "installments" %}
             {% assign lastInstallment = product.spark_pay_installments.last %}
-            <span aria-label="{{ oldest_payment_option.price | money_without_currency | remove: ',00' }} reais" class="final-price">{{ lastInstallment.value }}x de {{ lastInstallment.amount| money}}</span>
+            <span aria-label="{{ lastInstallment.value }} vezes de {{ lastInstallment.amount| money}} reais" class="final-price">{{ lastInstallment.value }}x de {{ lastInstallment.amount| money}}</span>
           {% else %}
             <span aria-label="{{ oldest_payment_option.price | money_without_currency | remove: ',00' }} reais" class="final-price">{{ oldest_payment_option.price | money_option_presentation_with_taxes: oldest_payment_option.kind, oldest_payment_option.period, gateway, oldest_payment_option }} </span>
           {% endif %}

--- a/snippets/product/product-card.liquid
+++ b/snippets/product/product-card.liquid
@@ -35,7 +35,12 @@
         {% endif %}
 
         {% if has_express_checkout == true %}
-          <span aria-label="{{ oldest_payment_option.price | money_without_currency | remove: ',00' }} reais" class="final-price">{{ oldest_payment_option.price | money_option_presentation_with_taxes: oldest_payment_option.kind, oldest_payment_option.period, gateway, oldest_payment_option }} </span>
+          {% if gateway.price_format == "installments" %}
+            {% assign lastInstallment = product.spark_pay_installments.last %}
+            <span aria-label="{{ oldest_payment_option.price | money_without_currency | remove: ',00' }} reais" class="final-price">{{ lastInstallment.value }}x de {{ lastInstallment.amount| money}}</span>
+          {% else %}
+            <span aria-label="{{ oldest_payment_option.price | money_without_currency | remove: ',00' }} reais" class="final-price">{{ oldest_payment_option.price | money_option_presentation_with_taxes: oldest_payment_option.kind, oldest_payment_option.period, gateway, oldest_payment_option }} </span>
+          {% endif %}
         {% else %}
           {% if first_option.kind == 'subscription' %}
             <span  class="final-price"> {{ first_option.price | money_option_presentation: first_option.kind, first_option.period, 'full', 1 }}</span>


### PR DESCRIPTION
# Correction of installments price view option in the cards of the home

Link to task on software project manager:
https://technical-solutions-herospark.atlassian.net/browse/TEM-376

## Changes outline
It was included a verification to validate if it's active the installments view in the spark_pay options. With this verification we can show the installments in the correct way with the taxes included
https://github.com/Edools/elegance/commit/b6eec449fa5458d602bf16856d27dbf0060e1360

## Expected behaviour
Now we can see the correct amount of the installments in the product card, in a independent way if we choose to show the full price or in installments.

## Front end changes
Before:
Difference between the product card, the product page and the express_checkout page.
![image](https://user-images.githubusercontent.com/61481152/114598732-9c6f3e00-9c68-11eb-8269-321f41a3cf4f.png)
![image](https://user-images.githubusercontent.com/61481152/114598784-adb84a80-9c68-11eb-89bc-074106b21f06.png)
![image](https://user-images.githubusercontent.com/61481152/114598826-ba3ca300-9c68-11eb-872f-e1dcc48a3d82.png)
After:
Same price view in all pages.
![image](https://user-images.githubusercontent.com/61481152/114599038-f5d76d00-9c68-11eb-8ec6-2e56f5c6d314.png)

