### PR TITLE
[BM-1037] Corrige condição do bloqueio de Lesson

### DIFF
--- a/templates/lesson.liquid
+++ b/templates/lesson.liquid
@@ -68,8 +68,8 @@
             <h2 class="lesson-title">{{ lesson.title }}</h2>
           </div>
 
-          {% if lesson.lock_at %}
-              <h1>{{ 'lesson.blocked' | t}}</h1>
+          {% if lesson.block_due_lock_date %}
+            <h1>{{ 'lesson.blocked' | t}}</h1>
           {% else %}
             {% if lesson.description.size > 0 %}
               <div class="lesson-description">


### PR DESCRIPTION
# Task title

[BM-1037]

## Changes outline

* Eu ajustei a condição de bloqueio de aulas

## Expected behaviour

* Quando a data de bloqueio da aula for passado, a aula deve aparecer bloqueada. Caso contrário, deve ser exibida normalmente.


[BM-1037]: https://technical-solutions-herospark.atlassian.net/browse/BM-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ