### PR TITLE
[BM-1213] Corrige a condição de exibição do botão de download

### DIFF
--- a/assets/js/components/lessonList.js
+++ b/assets/js/components/lessonList.js
@@ -623,7 +623,7 @@
 
                 var isDownloadableMedia = content.lesson.media && ['Document', 'Audio', 'Download'].indexOf(content.lesson.media.type) > -1;
 
-                if ((self.downloadAction || content.downloadable) && isDownloadableMedia)
+                if (self.downloadAction && content.downloadable && isDownloadableMedia)
                   html += '<a class="download-link" href="' + self.getContentDownloadPath(content) + '" data-no-turbolink>' +
                     '<i class="icon-cloud-download"></i>' +
                     '</a>';


### PR DESCRIPTION
# Task title

[BM-1213]

## Changes outline

* Eu corrigi a condição de exibição do botão de Download. Antes, caso "self.downloadAction" fosse verdadeiro o botão seria exibido, mesmo que o "content.downloadable" fosse falso.

## Expected behaviour

* Caso o conteúdo esteja configurado para não permitir o download, é esperado que o botão não seja exibido.

[BM-1213]: https://technical-solutions-herospark.atlassian.net/browse/BM-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ