### PR TITLE
Remove app modal

### DIFF
--- a/snippets/navbar.liquid
+++ b/snippets/navbar.liquid
@@ -47,6 +47,7 @@
 
 
         {% if current_user %}
+          {% comment %}
           {% if settings.view.general.navbar.app_modal == true %}
             <li class="appModalDesktop_button-nav">
                 <a href="javascript:;">
@@ -56,6 +57,7 @@
                 </a>
             </li>
           {% endif %}
+          {% endcomment %}
 
           <li>
             {% assign new_forum = current_school | has_feature: 'new_forum' %}
@@ -113,7 +115,8 @@
   </div>
 </header>
 
-
+{% comment %}
   {% if current_user and settings.view.general.navbar.app_modal == true %}
     {% include 'app-modal' %}
   {% endif %}
+{% endcomment %}


### PR DESCRIPTION
# App modal temporarily removed

[BM-1157](https://technical-solutions-herospark.atlassian.net/browse/BM-1157)
## Changes outline

* I commented the code used to call the modal

## Expected behaviour

* Don't show the modal when the page is opened
## Front end changes

* Before:
![image](https://user-images.githubusercontent.com/61481152/172930150-6f6b9250-0c16-4fbe-8712-76e5ad6e3300.png)
![image](https://user-images.githubusercontent.com/61481152/172930314-661adef7-1dac-4844-864e-382e5563e4f6.png)


* After:
![image](https://user-images.githubusercontent.com/61481152/172930040-37247e98-c3c7-498a-83d7-ebf84707806d.png)

